### PR TITLE
Replaced go-bindata with go1.16's embed feature

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -27,10 +27,6 @@ $env:GOARCH=$null
 
 $returnValue = 0
 
-# Generate assets.go
-go generate
-if ($LastExitCode -ne 0) { $returnValue = $LastExitCode }
-
 # Build for each architecture
 Foreach ($arch in $Architectures)
 {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/benpye/wsl-ssh-pageant
 
-go 1.12
+go 1.16
 
 require (
 	github.com/Microsoft/go-winio v0.4.11
@@ -12,7 +12,6 @@ require (
 	github.com/getlantern/hidden v0.0.0-20190325191715-f02dbb02be55 // indirect
 	github.com/getlantern/ops v0.0.0-20190325191751-d70cb0d6f85f // indirect
 	github.com/getlantern/systray v0.0.0-20190131073753-26d5b920200d
-	github.com/go-bindata/go-bindata v3.1.1+incompatible // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/lxn/win v0.0.0-20181015143721-a7f87360b10e
 	github.com/oxtoacart/bpool v0.0.0-20190227141107-8c4636f812cc // indirect

--- a/main.go
+++ b/main.go
@@ -1,6 +1,5 @@
 package main
 
-//go:generate go run github.com/go-bindata/go-bindata/go-bindata -pkg $GOPACKAGE -o assets.go assets/
 
 import (
 	"bufio"
@@ -19,6 +18,8 @@ import (
 	"syscall"
 	"unsafe"
 
+	_ "embed"
+
 	"github.com/Microsoft/go-winio"
 	"github.com/apenwarr/fixconsole"
 	"github.com/getlantern/systray"
@@ -32,6 +33,9 @@ var (
 	verbose     = flag.Bool("verbose", false, "Enable verbose logging")
 	systrayFlag = flag.Bool("systray", false, "Enable systray integration")
 	force       = flag.Bool("force", false, "Force socket usage (unlink existing socket)")
+
+	//go:embed assets/icon.ico
+	icon []byte
 )
 
 const (
@@ -314,10 +318,7 @@ func onSystrayReady() {
 	systray.SetTitle("WSL-SSH-Pageant")
 	systray.SetTooltip("WSL-SSH-Pageant")
 
-	data, err := Asset("assets/icon.ico")
-	if err == nil {
-		systray.SetIcon(data)
-	}
+	systray.SetIcon(icon)
 
 	quit := systray.AddMenuItem("Quit", "Quits this app")
 


### PR DESCRIPTION
Go 1.16 introduced a language built-in file embedding feature, 'go embed'.
This patch replaces the use of go-bindata with go-embed regarding the systray icon.
By this change, the 'go generate' stage could be removed from the build process; hence the package would be directly installable with 'go install' command.
